### PR TITLE
Fix frame creating

### DIFF
--- a/v2/frame.go
+++ b/v2/frame.go
@@ -121,9 +121,12 @@ type IdFrame struct {
 }
 
 func NewIdFrame(ft FrameType, ownerId string, id []byte) *IdFrame {
+	// TODO test it
+	id = append([]byte{0}, id...) // or it will be wrong number of bytes with many consequences
+
 	head := FrameHead{
 		FrameType: ft,
-		size:      uint32(1 + len(ownerId) + len(id)),
+		size:      uint32(len(ownerId) + len(id)),
 	}
 
 	return &IdFrame{


### PR DESCRIPTION
I tried to add new private frame and it seems like it added normally. But, when I try to read this frame with method Bytes(), it produces wrong data. It should be like:
[99 111 109 46 97 112 112 108 101 46 115 116 114 101 97 109 105 110 103 46 116 114 97 110 115 112 111 114 116 83 116 114 101 97 109 84 105 109 101 115 116 97 109 112 0 0 0 0 0 0 1 236 48] But it was like:
[99 111 109 46 97 112 112 108 101 46 115 116 114 101 97 109 105 110 103 46 116 114 97 110 115 112 111 114 116 83 116 114 101 97 109 84 105 109 101 115 116 97 109 112 0 0 0 0 0 1 236 48 0]